### PR TITLE
Add `taplo` pre-commit hook to format and sort `toml` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,12 @@ repos:
     rev: 2024.08.19
     hooks:
       - id: sp-repo-review
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        # See options: https://taplo.tamasfe.dev/configuration/formatter-options.html
+        args: [--option, "reorder_arrays=true"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -92,7 +98,3 @@ repos:
         args: [--branch, main]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pappasam/toml-sort
-    rev: v0.23.1
-    hooks:
-      - id: toml-sort-fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ build-backend = 'setuptools.build_meta'
 name = "sphinx-all-contributors"
 requires-python = '>=3.12'
 version = "0.2.dev0"
-dynamic = [
-  "readme"
-]
+dynamic = ["readme"]
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -24,17 +22,15 @@ description = "all-contributors for Sphinx users"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+addopts = ["--showlocals", "--strict-config", "--strict-markers", "-ra"]
 xfail_strict = true
 filterwarnings = ["error"]
 log_cli_level = "info"
-testpaths = [
-  "tests"
-]
+testpaths = ["tests"]
 
 [tool.ruff.lint]
 extend-select = ["ALL"]
 ignore = ["COM812", "D203", "D212", "ISC001"]
 
 [tool.setuptools.dynamic]
-readme = {file = "README.md", content-type = "text/markdown"}
+readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Add `taplo` pre-commit hook to format and sort `toml` files.