### PR TITLE
Move requirements into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ name = "sphinx-all-contributors"
 requires-python = '>=3.12'
 version = "0.2.dev0"
 
+[project.optional-dependencies]
+all = ['sphinx-all-contributors[docs]']
+docs = ['sphinx-book-theme==1.1.3']
+
 [tool.mypy]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e sphinx-all-contributors[docs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e sphinx-all-contributors[docs]
+-e .[docs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
--e .
-sphinx-book-theme==1.1.3


### PR DESCRIPTION
Move requirements to keep all project dependencies in a single location.